### PR TITLE
Add better metadata to page headers

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,8 +29,8 @@ export default function Home(): JSX.Element {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      title={`${siteConfig.title} - ${siteConfig.tagline}`}
+      description="pog guides you through the setup of your kmk firmware on compatible keyboards">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
Currently, if you share the link to the pog website the link preview shows something generic:

<img width="479" alt="Screenshot 2024-06-11 at 17 49 15" src="https://github.com/JanLunge/pog-docs/assets/552452/bfa584ba-bc41-4c1c-ac28-89f8d69bc719">

This PR updates the Home() function so that the title and description make more sense in OpenGraph tags.